### PR TITLE
Issue#11: Add stripe credentials

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -17,3 +17,14 @@ VERSION=
 ENABLE_SENTRY=
 SENTRY_ENV=
 SENTRY_DSN=
+
+# ==============================================================================
+# Stripe Settings
+# ==============================================================================
+# Get the webhook secret by looking at the console output of the stripe-cli container.
+# These values are used by the web container and stripe-cli container.
+
+STRIPE_WEBHOOK_SECRET=whsec_xxxx
+STRIPE_DEVICE_NAME=Local <Your Name>
+STRIPE_PK_KEY=sk_test_xxxx
+STRIPE_SK_KEY=pk_test_xxxx

--- a/DjangoTemplate/settings/default.py
+++ b/DjangoTemplate/settings/default.py
@@ -168,3 +168,7 @@ LOGGING = {
         },
     },
 }
+
+STRIPE_API_PK = os.getenv("STRIPE_PK_KEY")
+STRIPE_API_SK = os.getenv("STRIPE_SK_KEY")
+STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET")


### PR DESCRIPTION
https://github.com/levimoore1992/Django-Template/issues/11

This ticket adds some stripe credentials to the main setup that could potentially be used by an application. It doesn't add it to the container right now because Im not sure if that would be necessary. One on hand if an app doesn't need payments then they'd have to delete that everytime and on the other if a lot of apps need to use it then they'll need to add it each time. So for now Ill play it by ear.