### PR TITLE
Issue#19: Add container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ To start the docker container with the application you only need 1 command
 ```
 docker compose up --build
 ```
+
+## Things you may consider replacing
+
+<ul>
+<li>The name of the main app is called "DjangoTemplate". You would need to change it in settings.py file as well</li>
+<li>The container name for the app is called djangoTemplate. You may want to change that as well</li>
+</ul>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
             timeout: 5s
             retries: 5
     web:
+        container_name: djangoTemplate
         build:
             context: .
             dockerfile: Dockerfile


### PR DESCRIPTION
https://github.com/levimoore1992/Django-Template/issues/19

this ticket just adds a container name to the django container

I do this just to make it a little easier to call the container rather than looking up the id

I only do it for the django container because no one would call the other ones really.