### PR TITLE
Issue #21 Add Django extensions library to local by extend

### DIFF
--- a/DjangoTemplate/settings/local_example.py
+++ b/DjangoTemplate/settings/local_example.py
@@ -15,7 +15,12 @@ ALLOWED_HOSTS.extend(
 MIDDLEWARE.append(
     "debug_toolbar.middleware.DebugToolbarMiddleware",
 )
-INSTALLED_APPS.append("debug_toolbar")
+INSTALLED_APPS.extend(
+    [
+        "debug_toolbar",
+        "django_extensions",
+    ]
+)
 DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG}
 DEBUG_TOOLBAR_PANELS = [
     "debug_toolbar_user_switcher.panels.UserPanel",


### PR DESCRIPTION
This doesnt actually add django exentions because it was already there but it changes the way we extend the INSTALLED_APPS list