### PR TITLE
Issue #67: Add Media settings to tests/settings

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -16,3 +16,7 @@ DATABASES = {
 }
 
 SENTRY_ENV = "test_runner"
+
+# This is added here because the tests need to be able to access the media files
+MEDIA_ROOT = BASE_DIR / "media"
+MEDIA_URL = "/media/"


### PR DESCRIPTION
https://github.com/levimoore1992/Django-Template/issues/67

This PR adds some media fields to the tests/settings file

This is because during unit tests it would add the media to the root directory without it.

I avoided, adding media to the default settings.py file, because that will be done differently