### PR TITLE
Issue#49: Make all logging seeable

### DIFF
--- a/DjangoTemplate/settings/local_example.py
+++ b/DjangoTemplate/settings/local_example.py
@@ -32,5 +32,19 @@ DEBUG_TOOLBAR_PANELS = [
 
 
 # Local Email
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+DEFAULT_FROM_EMAIL = 'admin@localhost'
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+LOGGING = {
+    "version": 1,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "DEBUG",
+    },
+}

--- a/DjangoTemplate/settings/local_example.py
+++ b/DjangoTemplate/settings/local_example.py
@@ -32,8 +32,8 @@ DEBUG_TOOLBAR_PANELS = [
 
 
 # Local Email
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-DEFAULT_FROM_EMAIL = 'admin@localhost'
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+DEFAULT_FROM_EMAIL = "admin@localhost"
 
 
 LOGGING = {


### PR DESCRIPTION
https://github.com/levimoore1992/Django-Template/issues/49

We add root to the logging and override default so that way we can see all the logging that happens locally