### PR TITLE
Issue #121 Add Secure SSL redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@
 # ==============================================================================
 DEBUG=True
 SECRET_KEY=xxx # generate from https://djecrety.ir/
+SECURE_SSL_REDIRECT=xxx # Set this to be false if you dont enable https on local machine
 
 
 # ==============================================================================

--- a/DjangoTemplate/settings/default.py
+++ b/DjangoTemplate/settings/default.py
@@ -26,6 +26,9 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "FALSE").upper() == "TRUE"
 
+# This is in case a user types in the http:// url domain. It will redirect to the https:// version
+SECURE_SSL_REDIRECT = os.getenv("SECURE_SSL_REDIRECT", "FALSE").upper() == "TRUE"
+
 # Version of Application
 VERSION = os.getenv("VERSION")
 


### PR DESCRIPTION
https://github.com/levimoore1992/Django-Template/issues/121

For this PR I add SECURE_SSL_REDIRECT to the settings file so that way any appliaction that has a ssl certificate (as msot should) would redirect to the secure site. If a site doesnt then the user can use env varaibles to set this variable to false as well as in local development as well